### PR TITLE
[#144886069] - Implement a command to switch backend instances with a…

### DIFF
--- a/cliaasfakes/fake_awsclient.go
+++ b/cliaasfakes/fake_awsclient.go
@@ -443,6 +443,10 @@ func (fake *FakeAWSClient) WaitForStatusReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeAWSClient) SwapLb(identifier string, vmidentifiers []string) error {
+	return nil
+}
+
 func (fake *FakeAWSClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()

--- a/cliaasfakes/fake_elbclient.go
+++ b/cliaasfakes/fake_elbclient.go
@@ -1,0 +1,53 @@
+package cliaasfakes
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/service/elb"
+)
+
+var EmptyLbDescription []*elb.LoadBalancerDescription = make([]*elb.LoadBalancerDescription, 0)
+
+//FakeElbClient Mock the elb client behavior
+type FakeElbClient struct {
+	Instances         []*elb.Instance
+	DescribeErr       bool
+	DeregisterErr     bool
+	DeregisterCapture []*elb.Instance
+	RegisterCapture   []*elb.Instance
+	RegisterErr       bool
+	LoadBalancerExist bool
+}
+
+//DescribeLoadBalancers Mock the DescribeLoadBalancers behavior
+func (c *FakeElbClient) DescribeLoadBalancers(input *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
+
+	if c.DescribeErr {
+		return nil, errors.New("Describe API error")
+	}
+	if !c.LoadBalancerExist {
+		return &elb.DescribeLoadBalancersOutput{LoadBalancerDescriptions: EmptyLbDescription}, nil
+	}
+	lbDescriptions := &elb.LoadBalancerDescription{
+		Instances: c.Instances,
+	}
+	return &elb.DescribeLoadBalancersOutput{LoadBalancerDescriptions: []*elb.LoadBalancerDescription{lbDescriptions}}, nil
+}
+
+//DeregisterInstancesFromLoadBalancer Mock the deregisterInstance method
+func (c *FakeElbClient) DeregisterInstancesFromLoadBalancer(input *elb.DeregisterInstancesFromLoadBalancerInput) (*elb.DeregisterInstancesFromLoadBalancerOutput, error) {
+	if c.DeregisterErr {
+		return nil, errors.New("")
+	}
+	c.DeregisterCapture = input.Instances
+	return nil, nil
+}
+
+//RegisterInstancesWithLoadBalancer Mock the registerInstance method
+func (c *FakeElbClient) RegisterInstancesWithLoadBalancer(input *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {
+	if c.RegisterErr {
+		return nil, errors.New("")
+	}
+	c.RegisterCapture = input.Instances
+	return nil, nil
+}

--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 type Client interface {
 	Delete(vmIdentifier string) error
 	Replace(vmIdentifier string, imageIdentifier string) error
+	SwapLb(identifier string, vmidentifiers []string) error
 }
 
 func NewAWSAPIClientAdaptor(client AWSClient) Client {
@@ -76,6 +77,10 @@ func (v *awsAPIClientAdaptor) Replace(identifier string, ami string) error {
 	return nil
 }
 
+func (v *awsAPIClientAdaptor) SwapLb(identifier string, vmidentifiers []string) error {
+	return v.client.SwapLb(identifier, vmidentifiers)
+}
+
 type gcpClient struct {
 	client *gcp.Client
 }
@@ -114,6 +119,10 @@ func (c *gcpClient) Replace(identifier string, sourceImageTarballURL string) err
 	}
 
 	return c.client.WaitForStatus(newInstance.Name, gcp.InstanceRunning)
+}
+
+func (c *gcpClient) SwapLb(identifier string, vmidentifiers []string) error {
+	return c.client.SwapLb(identifier, vmidentifiers)
 }
 
 func createGCPInstanceFromExisting(vmInstance *compute.Instance, diskName string, name string) *compute.Instance {

--- a/commands/cliaas.go
+++ b/commands/cliaas.go
@@ -44,8 +44,9 @@ type CliaasCommand struct {
 
 	ConfigFile ConfigFilePath `short:"c" long:"config" required:"true" description:"Path to config file"`
 
-	ReplaceVM ReplaceVMCommand `command:"replace-vm" description:"Create a new VM with the old VM's IP"`
-	DeleteVM  DeleteVMCommand  `command:"delete-vm" description:"Delete the VM that has the specified identifier"`
+	ReplaceVM        ReplaceVMCommand        `command:"replace-vm" description:"Create a new VM with the old VM's IP"`
+	DeleteVM         DeleteVMCommand         `command:"delete-vm" description:"Delete the VM that has the specified identifier"`
+	SwapLoadBalancer SwapLoadBalancerCommand `command:"swap-lb-backend" description:"Replace backend instances behind a load balancer"`
 }
 
 var Cliaas CliaasCommand

--- a/commands/swap_lb.go
+++ b/commands/swap_lb.go
@@ -1,0 +1,15 @@
+package commands
+
+
+type SwapLoadBalancerCommand struct {
+	Identifier string `long:"identifier" required:"true" description:"Identifier of the load balancer"`
+	VmIdentifiers []string `long:"vm-identifier" required:"true" description:"Identifier of backend instances"`
+}
+
+func (r *SwapLoadBalancerCommand) Execute([]string) error {
+	client, err := Cliaas.Config.NewClient()
+	if err != nil {
+		return err
+	}
+	return client.SwapLb(r.Identifier, r.VmIdentifiers)
+}

--- a/config.go
+++ b/config.go
@@ -128,12 +128,13 @@ func (c *AWSConfig) Complete() bool {
 
 func (c *AWSConfig) NewClient() (Client, error) {
 	ec2Client, err := NewEC2Client(c.AccessKeyID, c.SecretAccessKey, c.Region)
+	elbClient, err := NewElbClient(c.AccessKeyID, c.SecretAccessKey, c.Region)
 	if err != nil {
 		return nil, errwrap.Wrap(err, "failed to make ec2 client")
 	}
 
 	return NewAWSAPIClientAdaptor(
-		NewAWSClient(ec2Client, c.VPCID, clock.NewClock())), nil
+		NewAWSClient(ec2Client, elbClient, c.VPCID, clock.NewClock())), nil
 }
 
 type GCPConfig struct {

--- a/elb_client.go
+++ b/elb_client.go
@@ -1,0 +1,30 @@
+package cliaas
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elb"
+)
+
+type ElbClient interface {
+	DeregisterInstancesFromLoadBalancer(input *elb.DeregisterInstancesFromLoadBalancerInput) (*elb.DeregisterInstancesFromLoadBalancerOutput, error)
+	RegisterInstancesWithLoadBalancer(input *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error)
+	DescribeLoadBalancers(input *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+}
+
+func NewElbClient(
+	accessKeyID string,
+	secretAccessKey string,
+	region string,
+) (ElbClient, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	return elb.New(sess, &aws.Config{
+		Credentials: credentials.NewStaticCredentials(accessKeyID, secretAccessKey, ""),
+		Region:      aws.String(region),
+	}), nil
+}

--- a/iaas/azure/client.go
+++ b/iaas/azure/client.go
@@ -151,6 +151,10 @@ func (s *Client) Replace(identifier string, vhdURL string) error {
 	return err
 }
 
+func (s *Client) SwapLb(identifier string, vmidentifiers []string) error {
+	return nil
+}
+
 func (s *Client) generateInstanceCopy(sourceInstanceName string, newInstanceName string, localImageURL string, localOSDiskURL string) (*compute.VirtualMachine, error) {
 	instance, err := s.VirtualMachinesClient.Get(s.resourceGroupName, sourceInstanceName, compute.InstanceView)
 	if err != nil {

--- a/iaas/gcp/gcp_client.go
+++ b/iaas/gcp/gcp_client.go
@@ -28,6 +28,7 @@ type ClientAPI interface {
 	GetVMInfo(filter Filter) (*compute.Instance, error)
 	StopVM(instanceName string) error
 	CreateImage(tarball string) (string, error)
+	SwapLb(identifier string, vmidentifiers []string) error
 }
 
 type Client struct {
@@ -213,6 +214,10 @@ func (s *Client) WaitForStatus(vmName string, desiredStatus string) error {
 	case <-time.After(s.timeout):
 		return errors.New("polling for status timed out")
 	}
+}
+
+func (s *Client) SwapLb(identifier string, vmidentifiers []string) error {
+	return nil
 }
 
 type googleComputeClientWrapper struct {

--- a/iaas/gcp/gcpfakes/fake_client_api.go
+++ b/iaas/gcp/gcpfakes/fake_client_api.go
@@ -334,6 +334,10 @@ func (fake *FakeClientAPI) Invocations() map[string][][]interface{} {
 	return fake.invocations
 }
 
+func (fake *FakeClientAPI) SwapLb(identifier string, vmidentifiers []string) error {
+	return nil
+}
+
 func (fake *FakeClientAPI) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()


### PR DESCRIPTION

implement the load balancer switch the backend instances with AWS

An example command line:
./cliaas -c /tmp/config.yml swap-lb-backend --identifier opsmanelb (loadbalancer_name) --vm-identifier i-0c3d7d17dd8890bf0 (instance_id)

For GCP and Azure just have empty implementation. 

@abbyachau @z4ce @ryanpei 